### PR TITLE
[P2022-217] Switch to styled from mui

### DIFF
--- a/src/components/Counter/Counter.style.tsx
+++ b/src/components/Counter/Counter.style.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import { styled } from "@mui/material/styles";
 
 export const CounterWrapper = styled.div`
   position: absolute;

--- a/src/components/Select/Select.style.tsx
+++ b/src/components/Select/Select.style.tsx
@@ -1,5 +1,4 @@
-import { styled as styledmui } from "@mui/material/styles";
-import styled from "styled-components";
+import { styled } from "@mui/material/styles";
 import Select from "@mui/material/Select";
 
 export const SelectWrapper = styled.div`
@@ -8,6 +7,6 @@ export const SelectWrapper = styled.div`
   right: 5%;
 `;
 
-export const StyledSelect = styledmui(Select)`
+export const StyledSelect = styled(Select)`
   max-height: 50px;
 `;


### PR DESCRIPTION
There is small issue here. I import styled from "@mui/material/styles and in other files I see that styled is imported from "@mui/system". Should it stay that way or we should try to use one source of styled?