### PR TITLE
P2022-483 ProjectCard storybook

### DIFF
--- a/src/components/ProjectCard/styled.tsx
+++ b/src/components/ProjectCard/styled.tsx
@@ -12,7 +12,7 @@ export const StyledCard = styled(Card)(({ theme }) => ({
 
 export const CardContent = styled("div")({
   padding: 16,
-  maxWidth: "calc(100% - 84px)",
+  maxWidth: "calc(100% - 88px)",
 });
 
 export const Background = styled(Box)(({ theme }) => ({

--- a/src/stories/ProjectCard.stories.tsx
+++ b/src/stories/ProjectCard.stories.tsx
@@ -1,0 +1,37 @@
+import { ComponentStory } from "@storybook/react";
+import { ThemeProvider } from "@mui/material";
+
+import ProjectCard from "../components/ProjectCard";
+import ThreeDotsMenu from "../components/ThreeDotsMenu/ThreeDotsMenu";
+import { theme } from "../theme/mainTheme";
+import { mockMenuItems } from "../mockData/menuItems";
+
+export default {
+  title: "ProjectCard",
+  component: ProjectCard,
+};
+
+const Template: ComponentStory<typeof ProjectCard> = (args) => (
+  <ThemeProvider theme={theme}>
+    <ProjectCard {...args} />
+  </ThemeProvider>
+);
+
+export const WithoutMenuComponent = Template.bind({});
+
+WithoutMenuComponent.args = {
+  name: "Awesome project",
+};
+
+export const WithThreeDotsMenu = Template.bind({});
+
+WithThreeDotsMenu.args = {
+  name: "Awesome project",
+  menuComponent: <ThreeDotsMenu menuItems={mockMenuItems} />,
+};
+
+WithoutMenuComponent.parameters = WithThreeDotsMenu.parameters = {
+  controls: {
+    include: ["name"],
+  },
+};

--- a/src/stories/ProjectCard.stories.tsx
+++ b/src/stories/ProjectCard.stories.tsx
@@ -13,7 +13,9 @@ export default {
 
 const Template: ComponentStory<typeof ProjectCard> = (args) => (
   <ThemeProvider theme={theme}>
-    <ProjectCard {...args} />
+    <div style={{ maxWidth: 416 }}>
+      <ProjectCard {...args} />
+    </div>
   </ThemeProvider>
 );
 


### PR DESCRIPTION
[Check out the task in jira](https://tracker.intive.com/jira/browse/P2022-483)

- created two stories; one without `menuComponent` and another with `ThreeDotsMenu` component passed as prop.
- I excluded `menuComponent` control in storybook because to try different menu components we would have to pass a JSON object and it didn't seem to be very useful. Please let me know if you have an idea what's the best way to deal with props  of `ReactNode` type in storybook 😄 