### PR TITLE
[P2022-1395] issue details view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,8 @@ import {
   toBoard,
   toProjects,
 } from "./views/routes";
+import { Owl_componentsInput } from "./views/OwlInput/OwlInput";
+import { IssueDetails } from "./views/IssueDetails/IssueDetails";
 
 const Boards = () => {
   const { projectID } = useParams();
@@ -68,6 +70,7 @@ const App = () => {
           <Route path={toProject()} element={<Boards />} />
           <Route path={toBoard()} element={<Board />} />
           <Route path={toIssue()} element={<Issue />} />
+          <Route path='issue-details' element={<IssueDetails />} />
           <Route path='*' element={<Navigate to={toProjects} />} />
         </Routes>
       )}

--- a/src/api/projects/projectsApi.ts
+++ b/src/api/projects/projectsApi.ts
@@ -9,7 +9,7 @@ const FetchProjectsAPI = {
     const response = await makeRequest("/api/project", "GET", null);
     const projects = await response.json();
     console.log("get projects - status:", response.status);
-    return projects.result;
+    return projects.data;
   },
   addProject: async function (projectToAdd: DataObject) {
     const response = await makeRequest("/api/project/", "POST", projectToAdd);

--- a/src/components/Select/Select.style.tsx
+++ b/src/components/Select/Select.style.tsx
@@ -11,7 +11,9 @@ interface StyledSelectProps {
   blankValue?: boolean;
 }
 
-export const StyledFormControl = styled(FormControl)<StyledSelectProps>`
+export const StyledFormControl = styled(
+  ({ secondary, fullWidth, ...props }) => <FormControl {...props} />
+)<StyledSelectProps>`
   border-color: transparent;
 
   ${({ secondary }) =>
@@ -41,7 +43,9 @@ export const StyledFormControl = styled(FormControl)<StyledSelectProps>`
   }
 `;
 
-export const StyledSelect = styled(Select)<StyledSelectProps>`
+export const StyledSelect = styled(({ secondary, blankValue, ...props }) => (
+  <Select {...props} />
+))<StyledSelectProps>`
   height: 40px;
   background-color: ${({ theme }) => theme.palette.grey[200]};
   border: none;
@@ -81,7 +85,9 @@ export const StyledSelect = styled(Select)<StyledSelectProps>`
     `}
 `;
 
-export const StyledMenuItem = styled(MenuItem)<StyledSelectProps>`
+export const StyledMenuItem = styled(({ secondary, fullWidth, ...props }) => (
+  <MenuItem {...props} />
+))<StyledSelectProps>`
   background-color: #fff;
   white-space: inherit;
   color: ${({ theme }) => theme.palette.grey[600]};

--- a/src/modules/PageHeader/PageHeader.style.tsx
+++ b/src/modules/PageHeader/PageHeader.style.tsx
@@ -8,7 +8,9 @@ interface StyledWrapperProps {
   secondary?: boolean;
 }
 
-export const StyledGridItem = styled(Grid)<StyledWrapperProps>`
+export const StyledGridItem = styled(({ secondary, ...props }) => (
+  <Grid {...props} />
+))<StyledWrapperProps>`
   margin-left: 64px;
   justify-content: center;
   display: flex;

--- a/src/modules/PageHeader/PageHeader.tsx
+++ b/src/modules/PageHeader/PageHeader.tsx
@@ -13,10 +13,11 @@ import { toProjects } from "src/views/routes";
 
 export interface SectionProps {
   pageTitle: string;
-  buttonText: string;
+  buttonText?: string;
   buttonHandler?: MouseEventHandler;
   menuComponent?: React.ReactNode;
   returnLink?: string;
+  interactiveElement?: JSX.Element;
 }
 
 export default function PageHeader({
@@ -25,6 +26,7 @@ export default function PageHeader({
   buttonHandler = () => {},
   returnLink,
   menuComponent,
+  interactiveElement,
 }: SectionProps) {
   return (
     <Box>
@@ -39,7 +41,7 @@ export default function PageHeader({
         </StyledGridItem>
         <StyledGridItem secondary>
           {!!menuComponent && <CardActions>{menuComponent}</CardActions>}
-          <StyledButton onClick={buttonHandler}>{buttonText}</StyledButton>
+          {interactiveElement}
         </StyledGridItem>
       </StyledGrid>
     </Box>

--- a/src/modules/PageHeader/PageHeader.tsx
+++ b/src/modules/PageHeader/PageHeader.tsx
@@ -1,7 +1,5 @@
-import { MouseEventHandler } from "react";
 import Box from "@mui/material/Box";
 import {
-  StyledButton,
   StyledGrid,
   Title,
   SubTitle,
@@ -13,8 +11,6 @@ import { toProjects } from "src/views/routes";
 
 export interface SectionProps {
   pageTitle: string;
-  buttonText?: string;
-  buttonHandler?: MouseEventHandler;
   menuComponent?: React.ReactNode;
   returnLink?: string;
   interactiveElement?: JSX.Element;
@@ -22,8 +18,6 @@ export interface SectionProps {
 
 export default function PageHeader({
   pageTitle,
-  buttonText,
-  buttonHandler = () => {},
   returnLink,
   menuComponent,
   interactiveElement,

--- a/src/stories/PageHeader.stories.tsx
+++ b/src/stories/PageHeader.stories.tsx
@@ -15,5 +15,4 @@ export const WithoutText = Template.bind({});
 
 WithText.args = {
   pageTitle: "Projects",
-  buttonText: "New project",
 };

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -38,5 +38,8 @@
   "LoginLabel": "Login",
   "PasswordLabel": "Password",
   "ErrorInputText": "Incorrect input!",
-  "deleteProjectWarning": "Are you sure you want to delete this project?"
+  "deleteProjectWarning": "Are you sure you want to delete this project?",
+  "ToDo": "To do",
+  "InProgress": "In progress",
+  "Done": "Done"
 }

--- a/src/translations/pl.json
+++ b/src/translations/pl.json
@@ -38,5 +38,8 @@
   "LoginLabel": "Login",
   "PasswordLabel": "Hasło",
   "ErrorInputText": "Błędne dane wejściowe!",
-  "deleteProjectWarning": "Czy na pewno chcesz usunąć ten projekt?"
+  "deleteProjectWarning": "Czy na pewno chcesz usunąć ten projekt?",
+  "ToDo": "Do zrobienia",
+  "InProgress": "W trakcie",
+  "Done": "Wykonane"
 }

--- a/src/views/Board/Board.tsx
+++ b/src/views/Board/Board.tsx
@@ -11,6 +11,7 @@ import NewProjectDialog from "@modules/NewProjectDialog/NewProjectDialog";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
 import ViewWeekOutlinedIcon from "@mui/icons-material/ViewWeekOutlined";
 import { Alert } from "@mui/material";
+import { Button } from "@components/Button/Button";
 
 export const Board = () => {
   const [boards, setBoards] = useState(mockBoards);
@@ -49,10 +50,13 @@ export const Board = () => {
     <StyledPageWrapper>
       <PageHeader
         pageTitle={`${t("boardsTitle")} ${name}`}
-        buttonText={t("newIssueBtn")}
-        buttonHandler={() => console.log("button clicked")}
         menuComponent={<ThreeDotsMenu menuItems={menuOptions} />}
         returnLink={t("boardsBackLink")}
+        interactiveElement={
+          <Button onClick={() => console.log("button clicked")}>
+            {t("newIssueBtn")}
+          </Button>
+        }
       />
       {boardNumberAlert && (
         <Alert onClose={() => setBoardNumberAlert(false)} severity='error'>

--- a/src/views/IssueDetails/IssueDetails.style.tsx
+++ b/src/views/IssueDetails/IssueDetails.style.tsx
@@ -1,0 +1,50 @@
+import { Box, Typography } from "@mui/material";
+import { styled } from "@mui/material/styles";
+
+export const StyledPageWrapper = styled(Box)(({ theme }) => ({
+  marginTop: "80px",
+  backgroundColor: theme.palette.grey[50],
+  height: "calc(100vh - 80px)",
+  overflow: "auto",
+}));
+
+export const IssueBodyContent = styled(Box)({
+  padding: "48px 64px",
+});
+
+export const IssueTitle = styled(Typography)(({ theme }) => ({
+  fontSize: "20px",
+  lineHeight: "24px",
+  color: theme.palette.grey[700],
+  marginBottom: "40px",
+}));
+
+export const Label = styled(Typography)(({ theme }) => ({
+  fontSize: "12px",
+  lineHeight: "16px",
+  color: theme.palette.grey[500],
+  marginBottom: "16px",
+}));
+
+export const TextNormal = styled(Typography)(({ theme }) => ({
+  fontSize: "16px",
+  lineHeight: "24px",
+  color: theme.palette.grey[800],
+}));
+
+export const TextOutlined = styled(TextNormal)(({ theme }) => ({
+  border: `1px solid ${theme.palette.grey[200]}`,
+  padding: "12px 16px",
+  borderRadius: theme.shape.borderRadius,
+}));
+
+export const Section = styled(Box)(({ theme }) => ({
+  background: "#FFFFFF",
+  padding: "32px 48px 40px 48px",
+  borderRadius: theme.shape.borderRadius,
+  boxShadow: theme.customShadows.primary,
+
+  "&& .MuiBox-root:not(:last-of-type)": {
+    marginBottom: "32px",
+  },
+}));

--- a/src/views/IssueDetails/IssueDetails.tsx
+++ b/src/views/IssueDetails/IssueDetails.tsx
@@ -1,0 +1,78 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import Grid from "@mui/material/Grid";
+import Box from "@mui/material/Box";
+
+import PageHeader from "@modules/PageHeader/PageHeader";
+import { Select } from "@components/Select/Select";
+import {
+  StyledPageWrapper,
+  IssueBodyContent,
+  Section,
+  IssueTitle,
+  Label,
+  TextNormal,
+  TextOutlined,
+} from "./IssueDetails.style";
+
+export const IssueDetails = () => {
+  const { t } = useTranslation();
+  const issueStatus = [t("ToDo"), t("InProgress"), t("Done")];
+  const [status, setStatus] = useState<string>(t("ToDo"));
+
+  const handleSelect = (e: any) => {
+    setStatus(e.target.value);
+  };
+
+  return (
+    <StyledPageWrapper>
+      <PageHeader
+        returnLink='Return to Awesome project'
+        pageTitle='The Best Issue'
+        interactiveElement={
+          <Select
+            options={issueStatus}
+            value={status}
+            handleSelect={handleSelect}
+          />
+        }
+      />
+      <IssueBodyContent>
+        <Grid container spacing={4}>
+          <Grid item xs={8}>
+            <Section>
+              <IssueTitle>{t("dialogCreateProjectTitle")}</IssueTitle>
+              <Box>
+                <Label>{t("labelDescription")}</Label>
+                <TextNormal>
+                  Lorem ipsum dolor sit amet consectetur adipisicing elit. Iure
+                  iusto nostrum voluptatibus fugiat ducimus delectus officia
+                  aspernatur adipisci quibusdam consectetur, facere aut!
+                  Aspernatur quaerat dolorem repellat tempora possimus quas
+                  soluta!
+                </TextNormal>
+              </Box>
+              <Box>
+                <Label>{t("labelLinkedIssues")}</Label>
+                <TextOutlined>Apples & Oranges</TextOutlined>
+              </Box>
+            </Section>
+          </Grid>
+          <Grid item xs={4}>
+            <Section>
+              <Box>
+                <Label>{t("labelAssignee")}</Label>
+                <TextOutlined>Han Solo</TextOutlined>
+              </Box>
+              <Box>
+                <Label>{t("labelReporter")}</Label>
+                <TextOutlined>Joe Doe</TextOutlined>
+              </Box>
+            </Section>
+          </Grid>
+        </Grid>
+      </IssueBodyContent>
+    </StyledPageWrapper>
+  );
+};

--- a/src/views/Owl/Owl.tsx
+++ b/src/views/Owl/Owl.tsx
@@ -3,6 +3,7 @@ import PageHeader from "@modules/PageHeader/PageHeader";
 import { useTranslation } from "react-i18next";
 import { LoginView } from "../../components/Login/LoginView";
 import { styled } from "@mui/material/styles";
+import { Button } from "@components/Button/Button";
 
 export const StyledBox = styled(Box)(({}) => ({
   display: "flex",
@@ -17,7 +18,11 @@ export const Owl_components = () => {
     <Box>
       <PageHeader
         pageTitle={t("projectsTitle")}
-        buttonText={t("newProjectBtn")}
+        interactiveElement={
+          <Button onClick={() => console.log("works")}>
+            {t("newProjectBtn")}
+          </Button>
+        }
       />
       <StyledBox>
         <LoginView />

--- a/src/views/Projects/Projects.tsx
+++ b/src/views/Projects/Projects.tsx
@@ -9,6 +9,7 @@ import PageHeader from "@modules/PageHeader/PageHeader";
 import ProjectCard from "@components/ProjectCard";
 import ThreeDotsMenu from "@components/ThreeDotsMenu/ThreeDotsMenu";
 import Content from "@components/Content/Content";
+import { Button } from "@components/Button/Button";
 
 let FetchProjectsAPI: any;
 
@@ -66,8 +67,11 @@ export const Projects = () => {
         </ConfirmationDialog>
         <PageHeader
           pageTitle={t("projectsViewTitle")}
-          buttonText={t("newProjectBtn")}
-          buttonHandler={() => console.log("works")}
+          interactiveElement={
+            <Button onClick={() => console.log("works")}>
+              {t("newProjectBtn")}
+            </Button>
+          }
         />
         <StyledProjectList>
           <Grid container spacing={3}>


### PR DESCRIPTION
[https://tracker.intive.com/jira/browse/P2022-1395](https://tracker.intive.com/jira/browse/P2022-1395)


- changed PageHeader to enable taking Select as a child
- added issue details view (on temporary route)

BONUS FIXES
- on the fly removed console warnings in PageHeader and Select components (react not recognizing props)
- also changed property name returned from getProjects api so list of projects could be rendered