### PR TITLE
integration showing issue details with API

### DIFF
--- a/src/api/contsans.tsx
+++ b/src/api/contsans.tsx
@@ -15,3 +15,4 @@ export const API_ADD_NEW_STATUS =
   "https://patronageapi.herokuapp.com/api/status?code=";
 export const API_GET_STATUSES_LIST =
   "https://patronageapi.herokuapp.com/api/status";
+export const API_ISSUE = "https://patronageapi.herokuapp.com/api/issue/";

--- a/src/api/issue/mockIssueDetails.tsx
+++ b/src/api/issue/mockIssueDetails.tsx
@@ -1,0 +1,18 @@
+import { mockIssues } from "../../mockData/mockIssues";
+
+function sleep(ms = 1000) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+const mockIssueDetails = mockIssues[0];
+
+const MockIssueDetailsAPI = {
+  getData: async function (url: string) {
+    await sleep();
+    return { data: mockIssueDetails };
+  },
+};
+
+export default MockIssueDetailsAPI;

--- a/src/mockData/mockIssues.tsx
+++ b/src/mockData/mockIssues.tsx
@@ -8,6 +8,7 @@ export const mockIssues = [
     statusId: 1,
     id: 0,
     isActive: true,
+    assignUserId: "Han Solo",
   },
   {
     alias: "mock issue 2",

--- a/src/views/Board/Board.tsx
+++ b/src/views/Board/Board.tsx
@@ -47,6 +47,7 @@ export const Board = () => {
   const [boardNumberAlert, setBoardNumberAlert] = useState(false);
   const [boardNameAlert, setBoardNameAlert] = useState(false);
   const { boardId, projectName, projectId, board } = useParams();
+  const [state, setState] = useState({});
 
   useEffect(() => {
     async function fetchStatus() {
@@ -86,6 +87,9 @@ export const Board = () => {
       setFilteredIssues(filterIssuesByStatusId());
     }
     fetchIssues();
+    return () => {
+      setState({});
+    };
   }, []);
 
   const handleAddNewColumn = (inputValue: string) => {


### PR DESCRIPTION
https://tracker.intive.com/jira/browse/P2022-1714
- When displaying the details of a task from the API, we do not get information about the reporter, and about the assignee only assignUserId, but there is no GET method that allows us to extract data about the user. Also, there is no information about related tasks. In these fields (reporter, linked issues) I left information, such as on the project from figma, and in the field "assignee" assignUserId, the same as it is displayed in the single project table view.
- I did not change the data regarding the status of the task, because it is a separate task P2022-1714.
- Additionally, in Board's UseEffect, I added a solution to the problem I encountered while tapping the problem: "This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function." (modeled on https://stackoverflow.com/questions/54954385/react-useeffect-causing-cant-perform-a-react-state-update-on-an-unmounted-comp).